### PR TITLE
Create a `Config` in thread local storage use

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ how AWS credentials are read.
 - `REGION` defines the AWS region where the SQS queue and DynamoDB table are
   located.
 - `QUEUE_URL` defines the SQS queue polled for messages.
+- `TABLE_NAME` defines the name of the DynamoDB from which email messae data to
+  send will be read.
 - `DRY_RUN` when defined as the string `true` the queue will only be polled a
   single time and no email information will be transmitted to the email sending
   service(s).

--- a/src/email_id_message.rs
+++ b/src/email_id_message.rs
@@ -64,10 +64,7 @@ impl From<EmailIdMessage> for GetItemInput {
             s: Some(message.email_id),
             ..AttributeValue::default()
         };
-        let mut input = GetItemInput {
-            table_name: String::from("emails_test_db"),
-            ..GetItemInput::default()
-        };
+        let mut input = GetItemInput::default();
         input
             .key
             .insert(String::from("EmailId"), email_id_attribute);

--- a/src/email_message.rs
+++ b/src/email_message.rs
@@ -5,6 +5,31 @@ use std::convert::TryFrom;
 /// A `Recipient` represents an address to which a message will be sent.
 type Recipient = String;
 
+#[derive(Clone, Debug)]
+enum EmailStatus {
+    Pending,
+    Sending,
+    Sent,
+    Unknown,
+}
+
+impl Default for EmailStatus {
+    fn default() -> Self {
+        EmailStatus::Pending
+    }
+}
+
+impl From<&str> for EmailStatus {
+    fn from(status: &str) -> Self {
+        match status {
+            "Pending" => EmailStatus::Pending,
+            "Sending" => EmailStatus::Sending,
+            "Sent" => EmailStatus::Sent,
+            _ => EmailStatus::Unknown,
+        }
+    }
+}
+
 /// An attachment to an `EmailMessage`.
 #[derive(Clone, Debug, Default)]
 struct EmailMessageAttachment {
@@ -51,7 +76,8 @@ pub struct EmailMessage {
     sent_count: i32,
     /// DateTime of first successful email send.
     sent_at: Option<String>,
-    status: String,
+    /// Last known state of the message.
+    status: EmailStatus,
     /// SUBJECT of the email.
     subject: String,
     /// DateTime indicating the last time this record was updated.

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,8 +120,9 @@ async fn main() {
         dynamodb: &dynamodb,
         sqs: &sqs,
     };
+    let queue_url = &config.queue_url;
     loop {
-        let message_list = get_sqs_email_messages(&config.queue_url, client.sqs).await;
+        let message_list = get_sqs_email_messages(queue_url, client.sqs).await;
         let processed_messages = match message_list {
             Ok(messages) => process_messages(client.dynamodb, messages).await,
             Err(error) => {
@@ -135,7 +136,7 @@ async fn main() {
             .collect();
         let delete_messages_request = DeleteMessageBatchRequest {
             entries: entries_to_delete,
-            queue_url: config.queue_url.clone(),
+            queue_url: queue_url.into(),
         };
         info!("{:?}", delete_messages_request);
         if config.dry_run {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ async fn main() {
             queue_url: queue_url.into(),
         };
         info!("{:?}", delete_messages_request);
-        if config.dry_run {
+        if CONFIG.with(|config| config.dry_run) {
             break;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,15 +27,15 @@ struct Client<'a> {
 /// Defines the configuration for how the email service executable will interact with external
 /// services.
 #[derive(Clone, Debug, Default)]
-struct Config {
+pub struct Config {
     /// Whether or not this run is a dry run.
-    dry_run: bool,
+    pub dry_run: bool,
     /// From which email message ids will be read.
-    queue_url: String,
+    pub queue_url: String,
     /// Region from which services provided by AWS will be accessed.
-    region: Region,
+    pub region: Region,
     /// DynamoDB table from which email data will be read.
-    table_name: String,
+    pub table_name: String,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use rusoto_sqs::{DeleteMessageBatchRequest, DeleteMessageBatchRequestEntry};
 use rusoto_sqs::{ReceiveMessageError, ReceiveMessageRequest, Sqs, SqsClient};
 use simplelog::{Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
 use std::convert::TryFrom;
+use std::env;
 
 use email_id_message::EmailIdMessage;
 use email_message::{EmailMessage, ParseEmailMessageCode};
@@ -68,11 +69,13 @@ impl Config {
             });
         let queue_url = match std::env::var("QUEUE_URL") {
             Ok(url) => url,
-            Err(_) => panic!("QUEUE_URL must be provided."),
+            Err(env::VarError::NotPresent) => panic!("QUEUE_URL must be provided."),
+            Err(_) => panic!("QUEUE_URL could not be read."),
         };
         let table_name = match std::env::var("TABLE_NAME") {
             Ok(name) => name,
-            Err(_) => panic!("TABLE_NAME must be provided."),
+            Err(env::VarError::NotPresent) => panic!("TABLE_NAME must be provided."),
+            Err(_) => panic!("TABLE_NAME could not be read."),
         };
         Config {
             dry_run,

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,6 @@ impl Config {
             queue_url,
             region,
             table_name,
-            ..Config::default()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,9 @@ async fn get_email_message(
     client: &DynamoDbClient,
     message: EmailIdMessage,
 ) -> Result<EmailMessage, ParseEmailMessageCode> {
-    let response = client.get_item(GetItemInput::from(message)).await;
+    let mut input = GetItemInput::from(message);
+    input.table_name = "emails_test_db".into();
+    let response = client.get_item(input).await;
     match response {
         Ok(output) => EmailMessage::try_from(output),
         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,8 +121,7 @@ impl Config {
 #[tokio::main]
 async fn main() {
     TermLogger::init(LevelFilter::Info, LogConfig::default(), TerminalMode::Mixed).unwrap();
-    let config = Config::env();
-    info!("{:?}", config);
+    CONFIG.with(|config| info!("{:?}", config));
     let sqs = SqsClient::new(Config::region());
     let dynamodb = DynamoDbClient::new(Config::region());
     let client = Client {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ struct Config {
     queue_url: String,
     /// Region from which services provided by AWS will be accessed.
     region: Region,
+    /// DynamoDB table from which email data will be read.
+    table_name: String,
 }
 
 impl Config {
@@ -68,10 +70,15 @@ impl Config {
             Ok(url) => url,
             Err(_) => panic!("QUEUE_URL must be provided."),
         };
+        let table_name = match std::env::var("TABLE_NAME") {
+            Ok(name) => name,
+            Err(_) => panic!("TABLE_NAME must be provided."),
+        };
         Config {
             dry_run,
             queue_url,
             region,
+            table_name,
             ..Config::default()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,15 @@ impl Config {
         }
     }
 
+    /// Read the SQS queue URL configured by environment variables out of thread local storage.
+    ///
+    /// # Performance Notes
+    ///
+    /// This clones the value on `Config` in thread local storage.
+    fn queue_url() -> String {
+        CONFIG.with(|config| config.queue_url.clone())
+    }
+
     /// Read the `Region` configured by environment variables out of thread local storage.
     ///
     /// # Performance Notes
@@ -120,7 +129,7 @@ async fn main() {
         dynamodb: &dynamodb,
         sqs: &sqs,
     };
-    let queue_url = &config.queue_url;
+    let queue_url = &Config::queue_url();
     loop {
         let message_list = get_sqs_email_messages(queue_url, client.sqs).await;
         let processed_messages = match message_list {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,10 @@ impl Config {
     /// * If a `QUEUE_URL` environment variable is not set.
     ///
     fn env() -> Self {
-        let dry_run = std::env::var("DRY_RUN")
+        let dry_run = env::var("DRY_RUN")
             .map(|s| s.to_lowercase() == "true")
             .unwrap_or(false);
-        let region = std::env::var("AWS_REGION")
+        let region = env::var("AWS_REGION")
             .map(|s| match s.parse::<Region>() {
                 Ok(region) => region,
                 Err(error) => panic!("Unable to parse AWS_REGION={}. {}", s, error),
@@ -67,12 +67,12 @@ impl Config {
                 name: "localstack".into(),
                 endpoint: "localhost".into(),
             });
-        let queue_url = match std::env::var("QUEUE_URL") {
+        let queue_url = match env::var("QUEUE_URL") {
             Ok(url) => url,
             Err(env::VarError::NotPresent) => panic!("QUEUE_URL must be provided."),
             Err(_) => panic!("QUEUE_URL could not be read."),
         };
-        let table_name = match std::env::var("TABLE_NAME") {
+        let table_name = match env::var("TABLE_NAME") {
             Ok(name) => name,
             Err(env::VarError::NotPresent) => panic!("TABLE_NAME must be provided."),
             Err(_) => panic!("TABLE_NAME could not be read."),


### PR DESCRIPTION
Use the values pulled out of thread local storage when they are needed
rather than holding and passing a reference to `Config`. This makes
getting the `table_name` out of `Config` only where it is needed
significantly less onerous than passing a `Config` reference through all
the functions.

`table_name` can more easily be pulled from `Config` when it is needed
in order to create an appropriate `GetItemInput` based on the given
environment variables where they are being created.

Implement `TryFrom` to convert from `Message` to `EmailIdMessage`.

Closes #2
Closes #3