### PR TITLE
Update `rusoto_*` dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,16 +179,6 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -212,9 +207,9 @@ name = "email_service"
 version = "0.1.0"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_dynamodb 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_sqs 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_dynamodb 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_sqs 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -812,11 +807,11 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,8 +823,8 @@ dependencies = [
  "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_signature 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_signature 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -840,12 +835,12 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -859,23 +854,23 @@ dependencies = [
 
 [[package]]
 name = "rusoto_dynamodb"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto_signature"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,7 +881,7 @@ dependencies = [
  "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -896,13 +891,13 @@ dependencies = [
 
 [[package]]
 name = "rusoto_sqs"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1336,6 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -1353,7 +1349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
@@ -1426,11 +1421,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum rusoto_core 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "492ae34e8ba20e0521e028e19fc90a5650c2668b622b2220986de811bfe44f1e"
-"checksum rusoto_credential 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c981690595b685c0df4c8f695cbe2e3ed4cd7269bcbcf1e5db2e8e5afc043cfb"
-"checksum rusoto_dynamodb 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd66a250bff28089f5795ce6ab9f9f63788f0d917dea734af6bc0538686deac5"
-"checksum rusoto_signature 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e1692e8e8c4e1edfa5269fe12ca5806504dcac485ca337e386e201fe6fdd22d5"
-"checksum rusoto_sqs 0.43.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a20e3c650446c6b04508dc3b8597c04f9896f086d5896d2cfe338f502f00754b"
+"checksum rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
+"checksum rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba3e7cdf483d7198d9bca7414746d3ba656239e89e467b715d0571912f0b492f"
+"checksum rusoto_dynamodb 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "686192bf4c9dbaa4514e9eed71c082b6a62ab458a20dec944ed245b731bbf0d3"
+"checksum rusoto_signature 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
+"checksum rusoto_sqs 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c357b6cbd33dbaab191eeb52f031ec2e6e63b7616f82d299659dd52233060ae2"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-rusoto_core = "0.43.0-beta.1"
-rusoto_dynamodb = "0.43.0-beta.1"
-rusoto_sqs = "0.43.0-beta.1"
+rusoto_core = "0.43.0"
+rusoto_dynamodb = "0.43.0"
+rusoto_sqs = "0.43.0"
 serde = "1.0"
 serde_json = "1.0"
 simplelog = "0.7"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cargo build --release
 
 ## License
 
-This Paw Extension is released under the [MIT License](LICENSE). Feel free to
+This experiment is released under the [MIT License](LICENSE). Feel free to
 fork, and modify!
 
 Copyright © 2020 Bryan J Swift

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ how AWS credentials are read.
 
 [rusoto]: https://github.com/rusoto/rusoto
 [credential]: https://crates.io/crates/rusoto_credential
-[credential_chain_provider]: https://docs.rs/rusoto_credential/0.43.0-beta.1/rusoto_credential/struct.ChainProvider.html
+[credential_chain_provider]: https://docs.rs/rusoto_credential/0.43.0/rusoto_credential/struct.ChainProvider.html
 
 - `REGION` defines the AWS region where the SQS queue and DynamoDB table are
   located.

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ impl Config {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     TermLogger::init(LevelFilter::Info, LogConfig::default(), TerminalMode::Mixed).unwrap();
     CONFIG.with(|config| info!("{:?}", config));
     let sqs = SqsClient::new(Config::region());
@@ -156,6 +156,7 @@ async fn main() {
             break;
         }
     }
+    Ok(())
 }
 
 async fn process_messages(

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ impl Config {
             queue_url,
             region,
             table_name,
+            ..Config::default()
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ thread_local! {
     pub static CONFIG: Config = Config::env();
 }
 
+const LOCALSTACK_REGION: &str = "localstack";
+
 /// Hold references to external service clients so they only need to be allocated once.
 struct Client<'a> {
     /// Connection to DynamoDB
@@ -55,22 +57,24 @@ impl Config {
     ///
     /// # Panics
     ///
-    /// * If a region is provided via the `AWS_REGION` environment variable but fails to be parsed.
     /// * If a `QUEUE_URL` environment variable is not set.
+    /// * If a `TABLE_NAME` environment variable is not set.
     ///
     fn env() -> Self {
         let dry_run = env::var("DRY_RUN")
             .map(|s| s.to_lowercase() == "true")
             .unwrap_or(false);
         let region = env::var("AWS_REGION")
-            .map(|s| match s.parse::<Region>() {
-                Ok(region) => region,
-                Err(error) => panic!("Unable to parse AWS_REGION={}. {}", s, error),
-            })
-            .unwrap_or(Region::Custom {
-                name: "localstack".into(),
-                endpoint: "localhost".into(),
-            });
+            .map(|s| if s == LOCALSTACK_REGION {
+                    Region::Custom {
+                        name: LOCALSTACK_REGION.into(),
+                        endpoint: "localhost".into(),
+                    }
+                } else {
+                    Region::default()
+                }
+            )
+            .unwrap_or(Region::default());
         let queue_url = match env::var("QUEUE_URL") {
             Ok(url) => url,
             Err(env::VarError::NotPresent) => panic!("QUEUE_URL must be provided."),


### PR DESCRIPTION
Change behavior of `Region` parsing to rely on `rusoto_` for parsing
`Region` unless the `AWS_REGION` is specified as "localstack"
explicitly.